### PR TITLE
Add content size to enable full width blocks

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -25,7 +25,7 @@ module.exports = {
         screens: {
             'sm': '640px',
             'md': '768px',
-            'lg': '1024px',
+            'lg': tailpress.theme('settings.layout.contentSize', theme),
             'xl': tailpress.theme('settings.layout.wideSize', theme)
         }
     },

--- a/theme.json
+++ b/theme.json
@@ -2,6 +2,7 @@
   "version": 1,
   "settings": {
     "layout": {
+      "contentSize": "1024px",
       "wideSize": "1280px"
     },
     "color": {


### PR DESCRIPTION
I tested the theme today and I saw that the block alignment option "Full width" is not available.

When you set the content size field in the theme.json it works as expected:
![image](https://user-images.githubusercontent.com/10296479/154977311-50d6b5bc-ff89-4979-a385-d3d5f86b0497.png)
