### PR TITLE
perf: move app.js to end before body

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -42,7 +42,7 @@ function tailpress_enqueue_scripts() {
 	$theme = wp_get_theme();
 
 	wp_enqueue_style( 'tailpress', tailpress_asset( 'css/app.css' ), array(), $theme->get( 'Version' ) );
-	wp_enqueue_script( 'tailpress', tailpress_asset( 'js/app.js' ), array(), $theme->get( 'Version' ) );
+	wp_enqueue_script( 'tailpress', tailpress_asset( 'js/app.js' ), array(), $theme->get( 'Version' ), true );
 }
 
 add_action( 'wp_enqueue_scripts', 'tailpress_enqueue_scripts' );


### PR DESCRIPTION
The app.js script appear at top of the html tag. This cause some script like SwiperJS can't running.
So I move it to end before body tag.