### PR TITLE
Enable Tailwind's nesting plugin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
 				"esbuild": "^0.12.24",
 				"postcss": "^8.4.4",
 				"postcss-import": "^14.0.0",
-				"postcss-nested": "^5.0.3",
 				"postcss-nested-ancestors": "^2.0.0",
 				"resolve-url-loader": "^3.1.2",
 				"tailwindcss": "^3.1.0"

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
 		"esbuild": "^0.12.24",
 		"postcss": "^8.4.4",
 		"postcss-import": "^14.0.0",
-		"postcss-nested": "^5.0.3",
 		"postcss-nested-ancestors": "^2.0.0",
 		"resolve-url-loader": "^3.1.2",
 		"tailwindcss": "^3.1.0"

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,6 @@
 module.exports = {
     plugins: [
         require('postcss-nested-ancestors'),
-        require('postcss-nested'),
         require('postcss-import'),
         require('tailwindcss/nesting'),
         require('tailwindcss')

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -3,6 +3,7 @@ module.exports = {
         require('postcss-nested-ancestors'),
         require('postcss-nested'),
         require('postcss-import'),
+        require('tailwindcss/nesting'),
         require('tailwindcss')
     ]
 }


### PR DESCRIPTION
Enable Tailwind's nesting plugin as described in the Tailwind docs: https://tailwindcss.com/docs/using-with-preprocessors#nesting. This allows custom nested classes to use Tailwind's modifiers.