### PR TITLE
tw 3.1 adds first party typescript types

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,6 +1,7 @@
 const theme = require('./theme.json');
 const tailpress = require("@jeffreyvr/tailwindcss-tailpress");
 
+/** @type {import('tailwindcss').Config} */
 module.exports = {
     content: [
         './*.php',


### PR DESCRIPTION
New Tailwind 3.1+ projects come with scaffolding that includes a line adding support for first party TypeScript types:

```js
/** @type {import('tailwindcss').Config} */
```

Mentioned in the video from tailwindlabs "[Whats New in Tailwind v3.1](https://youtu.be/nOQyWbPO2Ds?t=69)"