### PR TITLE
Add support for responsive embeds

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -29,6 +29,8 @@ function tailpress_setup() {
 	add_theme_support( 'align-wide' );
 	add_theme_support( 'wp-block-styles' );
 
+	add_theme_support( 'responsive-embeds' );
+
 	add_theme_support( 'editor-styles' );
 	add_editor_style( 'css/editor-style.css' );
 }


### PR DESCRIPTION
This PR adds support for responsive embedded content.

https://developer.wordpress.org/block-editor/how-to-guides/themes/theme-support/#responsive-embedded-content